### PR TITLE
.grab() arguments to a single optional options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Provides for an easy way to grab URLs of startup companies.
 `callback` takes the form of `( err, instance )` and is called when the initial loading of the module is done. Not using the callback results in a race condition when attempting to load and use providers.
 
 ### grab( *options*, callback )
-Starts grabbing links and taking screenshots of websites based on the options specified. The `options` argument is optional, and defaults to the following:
+Starts grabbing links and taking screenshots of websites based on the options specified.
 
-```json
+The `options` argument is optional, and defaults to the following:
+
+```
 {
 	howMany: 100,
 	provider: randomProvider,

--- a/README.md
+++ b/README.md
@@ -15,8 +15,17 @@ Provides for an easy way to grab URLs of startup companies.
 ### constructor( callback )
 `callback` takes the form of `( err, instance )` and is called when the initial loading of the module is done. Not using the callback results in a race condition when attempting to load and use providers.
 
-### grab( *howMany=100*, *providerName="500"*, callback )
-Start to grab links and emit them. Both *howMany* and *providerName* are optional. `callback` takes a single error as an argument.
+### grab( *options*, callback )
+Starts grabbing links and taking screenshots of websites based on the options specified. The `options` argument is optional, and defaults to the following:
+
+```json
+{
+	howMany: 100,
+	provider: randomProvider,
+	links: true,
+	screenshots: false
+}
+```
 
 ### availableProviders()
 Returns a simple array of names of providers; Right now only 500 Startups is used.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Returns a simple array of names of providers; Right now only 500 Startups is use
 If you'd like to stop the grab that is currently going on.
 
 ## Examples
-**Example**: Grab the first ~100 links.
+**Example**: Grab the first ~100 links from a random provider.
 ```js
 const StartupWebsiteGrabber = require( "startup-website-grabber" );
 
@@ -49,7 +49,7 @@ new StartupWebsiteGrabber( function( err, inst ){
 } );
 ```
 
-**Example**: Use an alternative limit on the maximum number of results returned.
+**Example**: Use an alternative limit on the maximum number of results returned from a specific provider.
 ```js
 const StartupWebsiteGrabber = require( "startup-website-grabber" );
 new StartupWebsiteGrabber( function( err, inst ){
@@ -57,7 +57,7 @@ new StartupWebsiteGrabber( function( err, inst ){
 		console.log( link );
 	} );
 
-	inst.grab( 1000, "500", function( err ){
+	inst.grab( { howMany: 1000, provider: "500" }, function( err ){
 		// done the grab.
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -3,9 +3,14 @@
   "version": "0.1.3",
   "description": "Grabs links to startup websites.",
   "keywords": "links scrape startup 500 500co grab crawl url urls",
-  "bugs": { "url" : "https://github.com/robertkeizer/startup-website-grabber/issues" },
+  "bugs": {
+    "url": "https://github.com/robertkeizer/startup-website-grabber/issues"
+  },
   "license": "BSD-2-Clause",
-  "repository": { "type": "git", "url": "https://github.com/robertkeizer/startup-website-grabber.git" },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/robertkeizer/startup-website-grabber.git"
+  },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha -t 60000"
   },
@@ -13,6 +18,7 @@
   "dependencies": {
     "async": "^2.5.0",
     "cheerio": "^1.0.0-rc.2",
+    "merge": "^1.2.0",
     "request": "^2.82.0"
   },
   "devDependencies": {

--- a/src/grabber.js
+++ b/src/grabber.js
@@ -70,7 +70,7 @@ Grabber.prototype.grab = function( options, cb ){
 		return _provider.name == optionsToUse.provider;
 	} );
 	if( _providersFound.length == 0 ){
-		return cb( "Provider " + optionsToUse.provider + " not found." );
+		return cb( "Provider '" + optionsToUse.provider + "' not found." );
 	}
 	const providerToUse = _providersFound[0];
 

--- a/src/grabber.js
+++ b/src/grabber.js
@@ -2,6 +2,7 @@ const fs		= require( "fs" );
 const async		= require( "async" );
 const EventEmitter	= require( "events" );
 const util		= require( "util" );
+const merge		= require( "merge" );
 
 const Grabber = function( cb ){
 
@@ -37,54 +38,93 @@ Grabber.prototype.availableProviders = function( ){
 	return this._providers.map( function( p ){ return p.name; } );
 };
 
-Grabber.prototype.grab = function( howMany, provider, cb ){
+Grabber.prototype.grab = function( options, cb ){
 
-	// Both provider and howMany are optional; These just
-	// allow us to mangle the arguments coming in.
-
-	if( !cb && typeof( provider ) == "function" ){
-		cb = provider;
-		provider = this._providers[Math.floor(Math.random()*this._providers.length)].name;
-	}else if( !cb && !provider && typeof( howMany ) == "function" ){
-		cb = howMany;
-		howMany = 100;
-		provider = this._providers[Math.floor(Math.random()*this._providers.length)].name;
+	// Allow only a callback to be specified; Shift the
+	// arguments.
+	if( !cb && typeof( options ) == "function" ){
+		cb = options;
+		options = { };
 	}
-	
+
+	// Define the default options that are going to be used
+	// if a particular option isn't specified.
+	const defaultOptions = {
+		howMany: 100,
+		provider: this._providers[Math.floor(Math.random()*this._providers.length)].name,
+		links: true,
+		screenshots: false
+	};
+
+	// Create a new object by using the default options and the options
+	// that were specified.
+	const optionsToUse = merge( defaultOptions, options );
+
+	// Bail if we already have a grab going.
 	if( this.inst ){
 		return cb( "Grab already happening. If you want concurrency use multiple instances of the grabber." );
 	}
 
+	// Bail if we couldn't find the provider.
 	const _providersFound = this._providers.filter( function( _provider ){
-		return _provider.name == provider;
+		return _provider.name == optionsToUse.provider;
 	} );
-
 	if( _providersFound.length == 0 ){
-		return cb( "Provider " + provider + " not found." );
+		return cb( "Provider " + optionsToUse.provider + " not found." );
 	}
+	const providerToUse = _providersFound[0];
 
 	const self	= this;
-	this.inst	= _providersFound[0].required( );
+	this.inst	= providerToUse.required( );
 	let _count	= 0;
+
+	// When we get a link, start the process of whether or not
+	// we emit it, and whether we should kick off a screenshot
+	// process.
 	this.inst.on( "link", function( link ){
+
+		// Increment the count so that we can determine
+		// if we've gone over.
 		_count++;
 
 		// If we've hit the limit; Stop.
-		if( _count >= howMany ){
+		if( _count >= optionsToUse.howMany ){
 			self.stop();
 		}
 
-		self.emit( "link", link );
+		// If we should be emitting links, let's 
+		// emit that link.
+		if( optionsToUse.links ){
+			self.emit( "link", link );
+		}
+
+		// If we're emitting a screenshot, let's get 
+		// that subroutine going; It takes care of
+		// emitting.
+		if( optionsToUse.screenshots ){
+			getScreenshot( link );
+		}
 	} );
 
+	// Helper function that is called when there is
+	// an error or the 'done' event fires; It clears the instnace
+	// of the provider from the instance of the grabber.
 	const cleanupInst = function( ){
 		self.inst = undefined;
 	};
 
+	// Translate from events in the instance to callbacks in the grabber
+	// instance. Also note that we clean up the instance here so that we can
+	// call grab() again.
 	this.inst.on( "error", function( err ){ cleanupInst(); return cb( err ); } );
 	this.inst.on( "done", function( ){ cleanupInst(); return cb( null ); } );
 };
 
+// Stops the instance that is running; Note that it 
+// doesn't clear anything that is currently going on, it simply
+// stops more queries from going out. There will be a delay of a few
+// events after this .stop() being called before all events stop from
+// this grabber instance.
 Grabber.prototype.stop = function( ){
 	if( this.inst ){ this.inst.emit( "die" ); }
 };

--- a/test/grabber.js
+++ b/test/grabber.js
@@ -20,7 +20,7 @@ describe( "Grabber", function( ){
 		} );
 	} );
 
-	it.only( "Grab works with default options", function( cb ){
+	it( "Grab works with default options", function( cb ){
 		const Grabber = require( "../src/grabber" );
 		new Grabber( function( err, inst ){
 			if( err ){ return cb( err ); }
@@ -37,36 +37,16 @@ describe( "Grabber", function( ){
 		} );
 	} );
 
-	it( "grab works with optional provider", function( cb ){
+	it( "Grab fails if provider not found", function( cb ){
 		const Grabber = require( "../src/grabber" );
 		new Grabber( function( err, inst ){
 			if( err ){ return cb( err ); }
 			
-			let _links = [ ];
-			inst.on( "link", function( link ){
-				_links.push( link );
-			} );
-			inst.grab( 1, function( err ){
-				if( err ){ return cb( err ); }
-				if( _links.length > 0 ){ return cb( null ); }
-				return cb( "No results returned." );
-			} );
-		} );
-	} );
-
-	it( "grab works with only a callback", function( cb ){
-		const Grabber = require( "../src/grabber" );
-		new Grabber( function( err, inst ){
-			if( err ){ return cb( err ); }
-			
-			let _links = [ ];
-			inst.on( "link", function( link ){
-				_links.push( link );
-			} );
-			inst.grab( function( err ){
-				if( err ){ return cb( err ); }
-				if( _links.length > 0 ){ return cb( null ); }
-				return cb( "No results returned." );
+			inst.grab( { provider: "nope" }, function( err ){
+				if( !err ){
+					return cb( "no error came back" );
+				}
+				return cb( null );
 			} );
 		} );
 	} );

--- a/test/grabber.js
+++ b/test/grabber.js
@@ -20,7 +20,7 @@ describe( "Grabber", function( ){
 		} );
 	} );
 
-	it( "grab works with all arguments specified", function( cb ){
+	it.only( "Grab works with default options", function( cb ){
 		const Grabber = require( "../src/grabber" );
 		new Grabber( function( err, inst ){
 			if( err ){ return cb( err ); }
@@ -29,7 +29,7 @@ describe( "Grabber", function( ){
 			inst.on( "link", function( link ){
 				_links.push( link );
 			} );
-			inst.grab( 1, "500", function( err ){
+			inst.grab( function( err ){
 				if( err ){ return cb( err ); }
 				if( _links.length > 0 ){ return cb( null ); }
 				return cb( "No results returned." );


### PR DESCRIPTION
We're going to have multiple options. Instead of extending the signature of the function, this'll make the design cleaner.